### PR TITLE
feat: Drop lowercase values of `x-sap-api-type`

### DIFF
--- a/sap-extensions/extensions.json
+++ b/sap-extensions/extensions.json
@@ -22,14 +22,7 @@
         "x-sap-api-type": {
           "type": "string",
           "description": "Type of API",
-          "oneOf": [
-            {
-              "enum": ["REST", "SOAP", "ODATA", "ODATAV4"]
-            },
-            {
-              "enum": ["rest", "soap", "odata", "odatav4"]
-            }
-          ],
+          "enum": ["REST", "SOAP", "ODATA", "ODATAV4"],
           "examples": ["REST", "SOAP", "ODATA", "ODATAV4"]
         },
         "x-sap-ext-overview": {

--- a/sap-extensions/extensions.json
+++ b/sap-extensions/extensions.json
@@ -23,7 +23,7 @@
           "type": "string",
           "description": "Type of API",
           "enum": ["REST", "SOAP", "ODATA", "ODATAV4"],
-          "examples": ["REST", "SOAP", "ODATA", "ODATAV4"]
+          "example": "REST"
         },
         "x-sap-ext-overview": {
           "type": "array",

--- a/sap-schemas/v2.0/schema.json
+++ b/sap-schemas/v2.0/schema.json
@@ -92,14 +92,7 @@
     "x-sap-api-type": {
       "type": "string",
       "description": "Type of API",
-      "oneOf": [
-        {
-          "enum": ["REST", "SOAP", "ODATA", "ODATAV4"]
-        },
-        {
-          "enum": ["rest", "soap", "odata", "odatav4"]
-        }
-      ],
+      "enum": ["REST", "SOAP", "ODATA", "ODATAV4"],
       "examples": ["REST", "SOAP", "ODATA", "ODATAV4"]
     },
     "x-sap-ext-overview": {

--- a/sap-schemas/v2.0/schema.json
+++ b/sap-schemas/v2.0/schema.json
@@ -93,7 +93,7 @@
       "type": "string",
       "description": "Type of API",
       "enum": ["REST", "SOAP", "ODATA", "ODATAV4"],
-      "examples": ["REST", "SOAP", "ODATA", "ODATAV4"]
+      "example": "REST"
     },
     "x-sap-ext-overview": {
       "type": "array",

--- a/sap-schemas/v3.0/schema.json
+++ b/sap-schemas/v3.0/schema.json
@@ -57,7 +57,7 @@
       "type": "string",
       "description": "Type of API",
       "enum": ["REST", "SOAP", "ODATA", "ODATAV4"],
-      "examples": ["REST", "SOAP", "ODATA", "ODATAV4"]
+      "example": {"x-sap-api-type": "REST"}
     },
     "x-sap-ext-overview": {
       "type": "array",

--- a/sap-schemas/v3.0/schema.json
+++ b/sap-schemas/v3.0/schema.json
@@ -57,7 +57,7 @@
       "type": "string",
       "description": "Type of API",
       "enum": ["REST", "SOAP", "ODATA", "ODATAV4"],
-      "example": {"x-sap-api-type": "REST"}
+      "example": "REST"
     },
     "x-sap-ext-overview": {
       "type": "array",

--- a/sap-schemas/v3.0/schema.json
+++ b/sap-schemas/v3.0/schema.json
@@ -56,14 +56,7 @@
     "x-sap-api-type": {
       "type": "string",
       "description": "Type of API",
-      "oneOf": [
-        {
-          "enum": ["REST", "SOAP", "ODATA", "ODATAV4"]
-        },
-        {
-          "enum": ["rest", "soap", "odata", "odatav4"]
-        }
-      ],
+      "enum": ["REST", "SOAP", "ODATA", "ODATAV4"],
       "examples": ["REST", "SOAP", "ODATA", "ODATAV4"]
     },
     "x-sap-ext-overview": {


### PR DESCRIPTION
Currently nobody is using lowercase values, therefore it's safe to drop them.