### PR TITLE
Chore: add links to OpenAPI format registry

### DIFF
--- a/sap-schemas/v2.0/README.md
+++ b/sap-schemas/v2.0/README.md
@@ -302,7 +302,7 @@ Constraints:
 
 - OPTIONAL
 - MUST be a positive integer
-- MUST be used with `"format": "decimal"`
+- MUST be used with [`"format": "decimal"`](https://spec.openapis.org/registry/format/decimal.html)
 - MAY be used with `"type": "string"`, `"type": "number"`, or any combination with these
 
 Example: `DECFLOAT34` value for `price`
@@ -340,7 +340,7 @@ Constraints:
 
 - OPTIONAL
 - MUST be a non-negative integer
-- MUST be used with `"format": "decimal"`
+- MUST be used with [`"format": "decimal"`](https://spec.openapis.org/registry/format/decimal.html)
 - MAY be used with `"type": "string"`, `"type": "number"`, or any combination with these
 
 Example: `DECIMAL(23,2)` value for `price`

--- a/sap-schemas/v3.0/README.md
+++ b/sap-schemas/v3.0/README.md
@@ -254,7 +254,7 @@ Constraints:
 
 - OPTIONAL
 - MUST be a positive integer
-- MUST be used with `"format": "decimal"`
+- MUST be used with [`"format": "decimal"`](https://spec.openapis.org/registry/format/decimal.html)
 - MAY be used with `"type": "string"`, `"type": "number"`, or any combination with these
 
 Example: `DECFLOAT34` value for `price`
@@ -300,7 +300,7 @@ Constraints:
 
 - OPTIONAL
 - MUST be a non-negative integer
-- MUST be used with `"format": "decimal"`
+- MUST be used with [`"format": "decimal"`](https://spec.openapis.org/registry/format/decimal.html)
 - MAY be used with `"type": "string"`, `"type": "number"`, or any combination with these
 
 Example: `DECIMAL(23,2)` value for `price`


### PR DESCRIPTION
The `decimal` format is going to appear in the OpenAPI Format Registry once https://github.com/OAI/OpenAPI-Specification/pull/3167 is merged
