### PR TITLE
Add x-sap-ord-id to link to ORD ID if existing / relevant

### DIFF
--- a/sap-extensions/extensions.json
+++ b/sap-extensions/extensions.json
@@ -139,6 +139,11 @@
           "description": "Indicates the direction of an API",
           "enum": ["inbound", "outbound", "mixed"],
           "default": "inbound"
+        },
+        "x-sap-ord-id": {
+          "type": "string",
+          "description": "ORD ID of the API Resource",
+          "pattern": "^([a-z0-9]+(?:[.][a-z0-9]+)*):(apiResource):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$"
         }
       }
     }

--- a/sap-schemas/v2.0/README.md
+++ b/sap-schemas/v2.0/README.md
@@ -244,7 +244,7 @@ Example:
 
 ```json
 {
-  "x-sap-ord-id": "sap.s4:apiResource:CE_BANK_0003:v3"
+  "x-sap-ord-id": "sap.s4:apiResource:OP_API_CATALOGPROFILE:v1"
 }
 ```
 

--- a/sap-schemas/v2.0/README.md
+++ b/sap-schemas/v2.0/README.md
@@ -227,6 +227,27 @@ Example:
 }
 ```
 
+### `x-sap-ord-id`
+
+- Type: `String`
+- Format: Valid [ORD ID for Event Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#event-resource_ordid)
+- Used at: [Swagger Object](https://spec.openapis.org/oas/v2.0#swagger-object) (root level)
+- Description: The ORD ID can be used to lookup more high-level metadata via Business Accelerator Hub or Unified Customer Landscape. It is also used when describing Integration Dependencies to indicate event subscriptions.
+
+Constraints:
+
+- OPTIONAL
+- MUST be a valid [ORD ID](https://sap.github.io/open-resource-discovery/spec-v1/#ord-id) for [Event Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#event-resource_ordid)
+  - Regexp: `^([a-z0-9]+(?:[.][a-z0-9]+)*):(eventResource):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$`
+
+Example:
+
+```json
+{
+  "x-sap-ord-id": "sap.s4:apiResource:CE_BANK_0003:v3"
+}
+```
+
 ## Schema level extensions
 
 ### `x-sap-odm-entity-name`

--- a/sap-schemas/v2.0/README.md
+++ b/sap-schemas/v2.0/README.md
@@ -230,15 +230,15 @@ Example:
 ### `x-sap-ord-id`
 
 - Type: `String`
-- Format: Valid [ORD ID for Event Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#event-resource_ordid)
+- Format: Valid [ORD ID for API Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#api-resource_ordid)
 - Used at: [Swagger Object](https://spec.openapis.org/oas/v2.0#swagger-object) (root level)
-- Description: The ORD ID can be used to lookup more high-level metadata via Business Accelerator Hub or Unified Customer Landscape. It is also used when describing Integration Dependencies to indicate event subscriptions.
+- Description: The ORD ID can be used to lookup more high-level metadata via Business Accelerator Hub or Unified Customer Landscape. It is also used when describing Integration Dependencies.
 
 Constraints:
 
 - OPTIONAL
-- MUST be a valid [ORD ID](https://sap.github.io/open-resource-discovery/spec-v1/#ord-id) for [Event Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#event-resource_ordid)
-  - Regexp: `^([a-z0-9]+(?:[.][a-z0-9]+)*):(eventResource):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$`
+- MUST be a valid [ORD ID](https://sap.github.io/open-resource-discovery/spec-v1/#ord-id) for [API Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#api-resource_ordid)
+  - Regexp: `^([a-z0-9]+(?:[.][a-z0-9]+)*):(apiResource):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$`
 
 Example:
 

--- a/sap-schemas/v2.0/schema.json
+++ b/sap-schemas/v2.0/schema.json
@@ -212,6 +212,11 @@
       "enum": ["inbound", "outbound", "mixed"],
       "default": "inbound"
     },
+    "x-sap-ord-id": {
+      "type": "string",
+      "description": "ORD ID of the API Resource",
+      "pattern": "^([a-z0-9]+(?:[.][a-z0-9]+)*):(apiResource):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$"
+    },
     "x-servers": {
       "type": "array",
       "description": "To specify multiple hosts",

--- a/sap-schemas/v3.0/README.md
+++ b/sap-schemas/v3.0/README.md
@@ -182,15 +182,15 @@ Example:
 ### `x-sap-ord-id`
 
 - Type: `String`
-- Format: Valid [ORD ID for Event Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#event-resource_ordid)
+- Format: Valid [ORD ID for API Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#api-resource_ordid)
 - Used at: [Swagger Object](https://spec.openapis.org/oas/v2.0#swagger-object) (root level)
-- Description: The ORD ID can be used to lookup more high-level metadata via Business Accelerator Hub or Unified Customer Landscape. It is also used when describing Integration Dependencies to indicate event subscriptions.
+- Description: The ORD ID can be used to lookup more high-level metadata via Business Accelerator Hub or Unified Customer Landscape. It is also used when describing Integration Dependencies.
 
 Constraints:
 
 - OPTIONAL
-- MUST be a valid [ORD ID](https://sap.github.io/open-resource-discovery/spec-v1/#ord-id) for [Event Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#event-resource_ordid)
-  - Regexp: `^([a-z0-9]+(?:[.][a-z0-9]+)*):(eventResource):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$`
+- MUST be a valid [ORD ID](https://sap.github.io/open-resource-discovery/spec-v1/#ord-id) for [API Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#api-resource_ordid)
+  - Regexp: `^([a-z0-9]+(?:[.][a-z0-9]+)*):(apiResource):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$`
 
 Example:
 

--- a/sap-schemas/v3.0/README.md
+++ b/sap-schemas/v3.0/README.md
@@ -179,6 +179,27 @@ Example:
 }
 ```
 
+### `x-sap-ord-id`
+
+- Type: `String`
+- Format: Valid [ORD ID for Event Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#event-resource_ordid)
+- Used at: [Swagger Object](https://spec.openapis.org/oas/v2.0#swagger-object) (root level)
+- Description: The ORD ID can be used to lookup more high-level metadata via Business Accelerator Hub or Unified Customer Landscape. It is also used when describing Integration Dependencies to indicate event subscriptions.
+
+Constraints:
+
+- OPTIONAL
+- MUST be a valid [ORD ID](https://sap.github.io/open-resource-discovery/spec-v1/#ord-id) for [Event Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#event-resource_ordid)
+  - Regexp: `^([a-z0-9]+(?:[.][a-z0-9]+)*):(eventResource):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$`
+
+Example:
+
+```json
+{
+  "x-sap-ord-id": "sap.s4:apiResource:CE_BANK_0003:v3"
+}
+```
+
 ## Schema level extensions
 
 ### `x-sap-odm-entity-name`

--- a/sap-schemas/v3.0/README.md
+++ b/sap-schemas/v3.0/README.md
@@ -183,7 +183,7 @@ Example:
 
 - Type: `String`
 - Format: Valid [ORD ID for API Resources](https://sap.github.io/open-resource-discovery/spec-v1/interfaces/document#api-resource_ordid)
-- Used at: [Swagger Object](https://spec.openapis.org/oas/v2.0#swagger-object) (root level)
+- Used at: [OpenAPI Object](https://spec.openapis.org/oas/v3.0.3#openapi-object) (root level)
 - Description: The ORD ID can be used to lookup more high-level metadata via Business Accelerator Hub or Unified Customer Landscape. It is also used when describing Integration Dependencies.
 
 Constraints:

--- a/sap-schemas/v3.0/README.md
+++ b/sap-schemas/v3.0/README.md
@@ -196,7 +196,7 @@ Example:
 
 ```json
 {
-  "x-sap-ord-id": "sap.s4:apiResource:CE_BANK_0003:v3"
+  "x-sap-ord-id": "sap.s4:apiResource:OP_API_CATALOGPROFILE:v1"
 }
 ```
 

--- a/sap-schemas/v3.0/schema.json
+++ b/sap-schemas/v3.0/schema.json
@@ -176,6 +176,11 @@
       "enum": ["inbound", "outbound", "mixed"],
       "default": "inbound"
     },
+    "x-sap-ord-id": {
+      "type": "string",
+      "description": "ORD ID of the API Resource",
+      "pattern": "^([a-z0-9]+(?:[.][a-z0-9]+)*):(apiResource):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$"
+    },
     "x-sap-extensible": {
       "title": "Extensibility Information",
       "type": "object",


### PR DESCRIPTION
Since the ORD ID is used to look up more high-level metadata and also needed when creating Integration Dependencies it would be very convenient for consumers (like the CAP framework) if the ORD ID is included in the OpenAPI document itself.